### PR TITLE
Remove runtime.SetFinalizer | buffer, caps and samples

### DIFF
--- a/gst/gst_buffer.go
+++ b/gst/gst_buffer.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"runtime"
 	"sync"
 	"time"
 	"unsafe"
@@ -48,7 +47,7 @@ func FromGstBufferUnsafeNone(buf unsafe.Pointer) *Buffer {
 	wrapped := ToGstBuffer(buf)
 	wrapped.mu = &sync.RWMutex{}
 	wrapped.Ref()
-	runtime.SetFinalizer(wrapped, (*Buffer).Unref)
+	//runtime.SetFinalizer(wrapped, (*Buffer).Unref)
 	return wrapped
 }
 
@@ -56,7 +55,7 @@ func FromGstBufferUnsafeNone(buf unsafe.Pointer) *Buffer {
 func FromGstBufferUnsafeFull(buf unsafe.Pointer) *Buffer {
 	wrapped := ToGstBuffer(buf)
 	wrapped.mu = &sync.RWMutex{}
-	runtime.SetFinalizer(wrapped, (*Buffer).Unref)
+	//runtime.SetFinalizer(wrapped, (*Buffer).Unref)
 	return wrapped
 }
 

--- a/gst/gst_caps.go
+++ b/gst/gst_caps.go
@@ -40,7 +40,7 @@ func FromGstCapsUnsafeNone(caps unsafe.Pointer) *Caps {
 	}
 	gocaps := ToGstCaps(caps)
 	gocaps.Ref()
-	runtime.SetFinalizer(gocaps, (*Caps).Unref)
+	//runtime.SetFinalizer(gocaps, (*Caps).Unref)
 	return gocaps
 }
 

--- a/gst/gst_sample.go
+++ b/gst/gst_sample.go
@@ -31,7 +31,7 @@ func FromGstSampleUnsafeNone(sample unsafe.Pointer) *Sample {
 // This is meant for internal usage and is exported for visibility to other packages.
 func FromGstSampleUnsafeFull(sample unsafe.Pointer) *Sample {
 	s := wrapSample(C.toGstSample(sample))
-	runtime.SetFinalizer(s, (*Sample).Unref)
+	//runtime.SetFinalizer(s, (*Sample).Unref)
 	return s
 }
 


### PR DESCRIPTION
Removed the `runtime.SetFinalizer` as now it is done manually by us in the `appsink_genrator` as we unref manually the objects.